### PR TITLE
Fix reserved word 'case' parsing error in serializeModel

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -538,9 +538,11 @@ serializeModel model =
                                     MoveMode -> "MoveMode"
                                     DeletionMode -> "DeletionMode" )
         , ( "inputText", Json.Encode.string model.inputText )
-        , ( "selectedPlaceNoteId", case model.selectedPlaceNoteId of
-            Just id -> Json.Encode.int id
-            Nothing -> Json.Encode.null )
+        , ( "selectedPlaceNoteId"
+          , case model.selectedPlaceNoteId of
+                Just id -> Json.Encode.int id
+                Nothing -> Json.Encode.null
+          )
         ]
 
 encodePlaceNotes : List PlaceNote -> Json.Encode.Value


### PR DESCRIPTION
Fixed Elm compiler error where 'case' keyword was being confused with a variable name. Reformatted the selectedPlaceNoteId tuple to split across multiple lines, making it clear to the parser that 'case' is a keyword introducing a case expression.